### PR TITLE
fix module duplicate

### DIFF
--- a/xoops_trust_path/modules/letag/preload/AssetPreload.class.php
+++ b/xoops_trust_path/modules/letag/preload/AssetPreload.class.php
@@ -33,10 +33,10 @@ class Letag_AssetPreloadBase extends XCube_ActionFilter
 	**/
 	public static function prepare(/*** string ***/ $dirname)
 	{
-		static $setupCompleted = false;
-		if(!$setupCompleted)
+		static $setupCompleted = array();
+		if(! isset($setupCompleted[$dirname]))
 		{
-			$setupCompleted = self::_setup($dirname);
+			$setupCompleted[$dirname] = self::_setup($dirname);
 		}
 	}
 


### PR DESCRIPTION
モジュールを複製し、複数の LeTag を使用する場合に、Delegate の発行が
最初のひとつの Letag についてしかされず、残りの Letag モジュールに
関しては、Delegate コールが効かない問題の修正です。
