### PR TITLE
fix typo (Parse error: syntax error)

### DIFF
--- a/xoops_trust_path/modules/letag/class/TagDelegateFunctions.class.php
+++ b/xoops_trust_path/modules/letag/class/TagDelegateFunctions.class.php
@@ -5,7 +5,7 @@
  * Date: 14/04/10
  * Time: 16:58
  */
-d
+
 class Letag_TagDelegate implements Legacy_iTagDelegate
 {
     /**


### PR DESCRIPTION
typo make `Parse error: syntax error, unexpected 'class' (T_CLASS) in /home/trust/pack/modules/letag/class/TagDelegateFunctions.class.php on line 9`
